### PR TITLE
feat: Feedback button posts GitHub issues via Pages Function

### DIFF
--- a/functions/api/feedback.js
+++ b/functions/api/feedback.js
@@ -1,0 +1,94 @@
+// Cloudflare Pages Function: POST /api/feedback
+// Creates a GitHub issue labelled "feedback" using a server-side PAT.
+// Required env (set in Pages dashboard):
+//   GITHUB_TOKEN  fine-grained PAT, Issues: Read+Write, scoped to one repo
+//   GITHUB_REPO   "owner/name"
+// Optional:
+//   TURNSTILE_SECRET  if set, requires a valid cf-turnstile-response token
+
+const MAX_MESSAGE = 4000;
+const MAX_CONTEXT = 2000;
+
+export async function onRequestPost(ctx) {
+  const { request, env } = ctx;
+
+  if (!env.GITHUB_TOKEN || !env.GITHUB_REPO) {
+    return json({ error: 'Server not configured' }, 500);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const message = String(body.message || '').trim();
+  const contextStr = body.context ? JSON.stringify(body.context, null, 2).slice(0, MAX_CONTEXT) : '';
+  const turnstileToken = body.turnstileToken;
+
+  if (!message) return json({ error: 'Message required' }, 400);
+  if (message.length > MAX_MESSAGE) return json({ error: 'Message too long' }, 400);
+
+  if (env.TURNSTILE_SECRET) {
+    const ok = await verifyTurnstile(env.TURNSTILE_SECRET, turnstileToken, request.headers.get('cf-connecting-ip'));
+    if (!ok) return json({ error: 'Captcha failed' }, 403);
+  }
+
+  const ua = request.headers.get('user-agent') || 'unknown';
+  const title = `[Feedback] ${message.split('\n')[0].slice(0, 80)}`;
+  const issueBody = [
+    message,
+    '',
+    '---',
+    '<details><summary>Context</summary>',
+    '',
+    '```',
+    `User-Agent: ${ua}`,
+    contextStr,
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
+
+  const res = await fetch(`https://api.github.com/repos/${env.GITHUB_REPO}/issues`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      'User-Agent': 'wcag-colour-finder-feedback',
+    },
+    body: JSON.stringify({ title, body: issueBody, labels: ['feedback'] }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return json({ error: 'GitHub API error', detail: text.slice(0, 500) }, 502);
+  }
+
+  const issue = await res.json();
+  return json({ url: issue.html_url, number: issue.number });
+}
+
+async function verifyTurnstile(secret, token, ip) {
+  if (!token) return false;
+  const form = new FormData();
+  form.append('secret', secret);
+  form.append('response', token);
+  if (ip) form.append('remoteip', ip);
+  const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    body: form,
+  });
+  const data = await res.json();
+  return Boolean(data.success);
+}
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -49,11 +49,8 @@ function buildModal() {
 }
 
 function init() {
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'fb-trigger';
-  btn.textContent = 'Feedback';
-  document.body.appendChild(btn);
+  const btn = document.querySelector('.fb-trigger');
+  if (!btn) return;
 
   const modal = buildModal();
   const textarea = modal.querySelector('#fb-message');

--- a/public/feedback.js
+++ b/public/feedback.js
@@ -1,0 +1,145 @@
+// Feedback button + modal. Posts to /api/feedback which creates a GitHub issue.
+
+const MAX_LEN = 4000;
+
+function gatherContext() {
+  const $ = (id) => document.getElementById(id);
+  const val = (id) => ($(id) ? $(id).value : null);
+  const text = (id) => ($(id) ? $(id).textContent : null);
+  return {
+    base: val('base-text'),
+    lightBg: val('light-bg-text'),
+    darkBg: val('dark-bg-text'),
+    target: document.querySelector('.target-opt.is-active')?.dataset.target || null,
+    lightFg: text('light-fg-hex'),
+    darkFg: text('dark-fg-hex'),
+    lightRatio: text('light-ratio'),
+    darkRatio: text('dark-ratio'),
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    url: window.location.href,
+  };
+}
+
+function buildModal() {
+  const wrap = document.createElement('div');
+  wrap.className = 'fb-modal';
+  wrap.setAttribute('role', 'dialog');
+  wrap.setAttribute('aria-modal', 'true');
+  wrap.setAttribute('aria-labelledby', 'fb-title');
+  wrap.hidden = true;
+  wrap.innerHTML = `
+    <div class="fb-backdrop" data-fb-close></div>
+    <div class="fb-panel">
+      <h2 id="fb-title">Send feedback</h2>
+      <p class="fb-hint">Tell us what's working, what's broken, or what's missing. Posts as a public GitHub issue.</p>
+      <textarea id="fb-message" maxlength="${MAX_LEN}" rows="6" placeholder="Your feedback…"></textarea>
+      <details class="fb-context">
+        <summary>This information will be sent with your feedback</summary>
+        <dl class="fb-context-list"></dl>
+      </details>
+      <div class="fb-actions">
+        <button type="button" class="fb-cancel" data-fb-close>Cancel</button>
+        <button type="button" class="fb-submit">Send</button>
+      </div>
+      <p class="fb-status" aria-live="polite"></p>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+  return wrap;
+}
+
+function init() {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'fb-trigger';
+  btn.textContent = 'Feedback';
+  document.body.appendChild(btn);
+
+  const modal = buildModal();
+  const textarea = modal.querySelector('#fb-message');
+  const status = modal.querySelector('.fb-status');
+  const submit = modal.querySelector('.fb-submit');
+  const contextList = modal.querySelector('.fb-context-list');
+
+  const renderContext = () => {
+    const ctx = gatherContext();
+    const ua = navigator.userAgent;
+    const rows = [
+      ['User-Agent', ua],
+      ['URL', ctx.url],
+      ['Viewport', ctx.viewport],
+      ['Base hex', ctx.base],
+      ['Light bg', ctx.lightBg],
+      ['Dark bg', ctx.darkBg],
+      ['Target', ctx.target],
+      ['Light fg', ctx.lightFg],
+      ['Dark fg', ctx.darkFg],
+      ['Light ratio', ctx.lightRatio],
+      ['Dark ratio', ctx.darkRatio],
+    ];
+    contextList.innerHTML = rows
+      .filter(([, v]) => v != null && v !== '')
+      .map(([k, v]) => `<dt>${k}</dt><dd>${escapeHtml(String(v))}</dd>`)
+      .join('');
+  };
+
+  const open = () => {
+    modal.hidden = false;
+    status.textContent = '';
+    textarea.value = '';
+    submit.disabled = false;
+    submit.textContent = 'Send';
+    renderContext();
+    setTimeout(() => textarea.focus(), 0);
+  };
+  const close = () => { modal.hidden = true; btn.focus(); };
+
+  btn.addEventListener('click', open);
+  modal.addEventListener('click', (e) => {
+    if (e.target.matches('[data-fb-close]')) close();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (!modal.hidden && e.key === 'Escape') close();
+  });
+
+  submit.addEventListener('click', async () => {
+    const message = textarea.value.trim();
+    if (!message) {
+      status.textContent = 'Please write something first.';
+      return;
+    }
+    submit.disabled = true;
+    submit.textContent = 'Sending…';
+    status.textContent = '';
+    try {
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, context: gatherContext() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        status.textContent = data.error || `Error ${res.status}`;
+        submit.disabled = false;
+        submit.textContent = 'Send';
+        return;
+      }
+      status.innerHTML = `Thanks! <a href="${data.url}" target="_blank" rel="noopener">View issue #${data.number}</a>`;
+      submit.textContent = 'Sent';
+    } catch (err) {
+      status.textContent = 'Network error. Try again.';
+      submit.disabled = false;
+      submit.textContent = 'Send';
+    }
+  });
+}
+
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
 
   <div class="topbar-wrap" id="topbar-wrap">
     <div class="topbar">
-      <span class="credit">Inspired by <a href="https://colourcontrast.cc" target="_blank" rel="noopener">colourcontrast.cc</a></span>
+      <span class="credit">Inspired by <a href="https://colourcontrast.cc" target="_blank" rel="noopener">colourcontrast.cc</a>. <button type="button" class="fb-trigger link-btn">Feedback</button>.</span>
       <div class="title-row">
         <h1>Accessible colour finder</h1>
         <p class="subtitle">Enter a hex colour to find close colour pairs accessible on light and dark backgrounds.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script type="module" src="app.js"></script>
+  <script type="module" src="feedback.js"></script>
 </head>
 <body>
 <main>

--- a/public/style.css
+++ b/public/style.css
@@ -70,6 +70,20 @@ h1 {
   font-weight: 500;
 }
 .credit a:hover { opacity: 0.75; }
+.credit .link-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.credit .link-btn:hover { opacity: 0.75; }
+.credit .link-btn:focus-visible { outline: 2px solid var(--topbar-fg); outline-offset: 2px; }
 .controls {
   display: block;
 }
@@ -594,24 +608,7 @@ button.alt:focus-visible {
   outline-offset: 2px;
 }
 
-/* --- Feedback button + modal --- */
-.fb-trigger {
-  position: fixed;
-  bottom: 16px;
-  right: 16px;
-  z-index: 90;
-  background: #111;
-  color: #fff;
-  border: 2px solid #fff;
-  border-radius: 999px;
-  padding: 10px 16px;
-  font: 600 14px 'Inter', system-ui, sans-serif;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
-}
-.fb-trigger:hover { background: #000; }
-.fb-trigger:focus-visible { outline: 2px solid #6BD4AC; outline-offset: 2px; }
-
+/* --- Feedback modal --- */
 .fb-modal {
   position: fixed;
   inset: 0;

--- a/public/style.css
+++ b/public/style.css
@@ -593,3 +593,113 @@ button.alt:focus-visible {
   outline: 2px solid var(--topbar-fg, #111111);
   outline-offset: 2px;
 }
+
+/* --- Feedback button + modal --- */
+.fb-trigger {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 90;
+  background: #111;
+  color: #fff;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font: 600 14px 'Inter', system-ui, sans-serif;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+}
+.fb-trigger:hover { background: #000; }
+.fb-trigger:focus-visible { outline: 2px solid #6BD4AC; outline-offset: 2px; }
+
+.fb-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+@media (max-width: 767px) {
+  .fb-modal { padding: 24px; }
+}
+.fb-modal[hidden] { display: none; }
+.fb-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+}
+.fb-panel {
+  position: relative;
+  background: #fff;
+  color: #111;
+  border: 2px solid #111;
+  border-radius: 8px;
+  padding: 24px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+.fb-panel h2 { margin: 0 0 8px; font-size: 20px; font-weight: 700; }
+.fb-hint { margin: 0 0 12px; font-size: 14px; color: #555; }
+.fb-panel textarea {
+  width: 100%;
+  font: 16px 'Inter', system-ui, sans-serif;
+  padding: 10px;
+  border: 2px solid #111;
+  border-radius: 4px;
+  resize: vertical;
+}
+.fb-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+.fb-actions button {
+  font: 600 14px 'Inter', system-ui, sans-serif;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 2px solid #111;
+  cursor: pointer;
+}
+.fb-cancel { background: #fff; color: #111; }
+.fb-submit { background: #111; color: #fff; }
+.fb-submit:disabled { opacity: 0.6; cursor: default; }
+.fb-status { margin: 10px 0 0; font-size: 14px; min-height: 1.2em; }
+.fb-status a { color: #111; }
+
+.fb-context {
+  margin-top: 12px;
+  font-size: 13px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: #fafafa;
+}
+.fb-context > summary {
+  cursor: pointer;
+  font-weight: 500;
+  color: #555;
+  user-select: none;
+}
+.fb-context[open] > summary { margin-bottom: 8px; }
+.fb-context-list {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  max-height: 200px;
+  overflow: auto;
+}
+.fb-context-list dt {
+  color: #555;
+  font-weight: 500;
+}
+.fb-context-list dd {
+  margin: 0;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  word-break: break-all;
+  color: #111;
+}


### PR DESCRIPTION
## Summary
- Adds a Feedback link in the topbar credit line that opens a modal
- Modal shows the user what context will be sent (UA, viewport, hex state, ratios) before submit
- POSTs to a new Cloudflare Pages Function at `/api/feedback` which creates a `feedback`-labelled GitHub issue using a server-side fine-grained PAT
- Optional Turnstile gating supported via `TURNSTILE_SECRET` env var

## Required environment variables (Pages → Settings → Variables and Secrets, both Production and Preview)
- `GITHUB_TOKEN` — fine-grained PAT, Issues: Read+Write, scoped to this repo (Secret)
- `GITHUB_REPO` — `jevawin/wcag-colour-finder` (Plaintext)

## Test plan
- [x] Branch preview deploy creates an issue end-to-end (verified via [#2](https://github.com/jevawin/wcag-colour-finder/issues/2))
- [ ] Smoke test from production preview after merge
- [ ] Confirm no regressions to topbar layout at mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)