### PR TITLE
feat: label hex pairs as Light/Dark + tidy credit line

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -240,14 +240,31 @@ if (typeof document !== 'undefined') {
       el.setAttribute('aria-label', isShade
         ? 'Apply pair: light #' + a.lightHex + ', dark #' + a.darkHex
         : 'Apply single #' + a.lightHex);
-      el.innerHTML =
-        '<div class="chips">' +
-          '<span class="chip light"></span>' +
-          (isShade ? '<span class="chip dark"></span>' : '') +
-        '</div>' +
-        '<div class="hex mono">' +
-          (isShade ? (a.lightHex + ' / ' + a.darkHex) : ('#' + a.lightHex)) +
-        '</div>';
+      el.innerHTML = isShade
+        ? (
+          '<div class="chips">' +
+            '<span class="chip light"></span>' +
+            '<span class="chip dark"></span>' +
+          '</div>' +
+          '<div class="info">' +
+            '<div class="hexes mono">' +
+              '<span>' + a.lightHex + '</span>' +
+              '<span>' + a.darkHex + '</span>' +
+            '</div>' +
+            '<div class="labels">' +
+              '<span>Light</span>' +
+              '<span>Dark</span>' +
+            '</div>' +
+          '</div>'
+        )
+        : (
+          '<div class="chips">' +
+            '<span class="chip light"></span>' +
+          '</div>' +
+          '<div class="info">' +
+            '<div class="hexes mono"><span>#' + a.lightHex + '</span></div>' +
+          '</div>'
+        );
       const isSelected = state.appliedLight === a.lightHex && state.appliedDark === a.darkHex;
       el.setAttribute('aria-pressed', String(isSelected));
       el.addEventListener('click', () => {

--- a/public/app.js
+++ b/public/app.js
@@ -421,6 +421,12 @@ if (typeof document !== 'undefined') {
     });
   }
   wireHexInput(baseText,    setBase, clearBase);
+
+  document.getElementById('base-clear').addEventListener('click', () => {
+    baseText.value = '';
+    clearBase();
+    baseText.focus();
+  });
   wireHexInput(lightBgText, setLightBg);
   wireHexInput(darkBgText,  setDarkBg);
 

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
 
   <div class="topbar-wrap" id="topbar-wrap">
     <div class="topbar">
-      <span class="credit">Inspired by <a href="https://colourcontrast.cc" target="_blank" rel="noopener">colourcontrast.cc</a>. <button type="button" class="fb-trigger link-btn">Feedback</button>.</span>
+      <span class="credit">Inspired by <a href="https://colourcontrast.cc" target="_blank" rel="noopener">colourcontrast.cc</a> – <button type="button" class="fb-trigger link-btn">feedback</button>.</span>
       <div class="title-row">
         <h1>Accessible colour finder</h1>
         <p class="subtitle">Enter a hex colour to find close colour pairs accessible on light and dark backgrounds.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,10 @@
               <input type="color" id="base-color" value="#6BD4AC" aria-label="Pick base colour">
             </span>
             <span class="hash mono">#</span>
-            <input id="base-text" type="text" value="" maxlength="6" spellcheck="false" autocomplete="off" aria-label="Hex colour code">
+            <input id="base-text" type="text" value="" maxlength="6" spellcheck="false" autocomplete="off" aria-label="Hex colour code" placeholder=" ">
+            <button type="button" class="clear-btn" id="base-clear" aria-label="Clear hex code">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4l8 8M12 4l-8 8"/></svg>
+            </button>
           </label>
           <div class="target-toggle" id="target-toggle" role="group" aria-label="Target WCAG level">
             <button type="button" class="target-opt is-active" data-target="AA" aria-pressed="true">AA</button>

--- a/public/style.css
+++ b/public/style.css
@@ -143,14 +143,11 @@ h1 {
   display: inline-flex;
   align-items: stretch;
   height: 72px;
-  border: var(--border-w) solid var(--topbar-fg);
-  border-radius: 6px;
-  background: var(--paper);
 }
 .target-opt {
   appearance: none;
-  border: 0;
-  background: transparent;
+  border: var(--border-w) solid var(--topbar-fg);
+  background: var(--paper);
   color: var(--ink);
   font-family: 'Inter', system-ui, sans-serif;
   font-weight: 700;
@@ -160,14 +157,17 @@ h1 {
   cursor: pointer;
   min-width: 64px;
 }
-.target-opt:first-child { border-radius: 4px 0 0 4px; }
-.target-opt:last-child  { border-radius: 0 4px 4px 0; }
-.target-opt + .target-opt {
-  border-left: var(--border-w) solid var(--topbar-fg);
-}
 .target-opt.is-active {
   background: #111111;
   color: #FFFFFF;
+}
+.target-toggle .target-opt:first-child {
+  border-right: 0;
+  border-radius: 6px 0 0 6px;
+}
+.target-toggle .target-opt:last-child {
+  border-left: 0;
+  border-radius: 0 6px 6px 0;
 }
 
 .toggle-row { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
@@ -369,7 +369,7 @@ h1 {
 }
 .hex-input .clear-btn { display: none; }
 .hex-input input[type="text"]:not(:placeholder-shown) ~ .clear-btn { display: inline-flex; }
-.hex-input .clear-btn:hover { opacity: 0.65; }
+.hex-input .clear-btn:hover svg { opacity: 0.65; }
 .hex-input .clear-btn:focus-visible { outline: 2px solid var(--ink); outline-offset: -4px; }
 .hex-input .clear-btn svg { width: 18px; height: 18px; display: block; }
 .copy-btn svg { width: 16px; height: 16px; display: block; }

--- a/public/style.css
+++ b/public/style.css
@@ -145,7 +145,6 @@ h1 {
   height: 72px;
   border: var(--border-w) solid var(--topbar-fg);
   border-radius: 6px;
-  overflow: hidden;
   background: var(--paper);
 }
 .target-opt {
@@ -161,6 +160,8 @@ h1 {
   cursor: pointer;
   min-width: 64px;
 }
+.target-opt:first-child { border-radius: 4px 0 0 4px; }
+.target-opt:last-child  { border-radius: 0 4px 4px 0; }
 .target-opt + .target-opt {
   border-left: var(--border-w) solid var(--topbar-fg);
 }
@@ -352,6 +353,25 @@ h1 {
   transition: opacity 0.15s;
 }
 .copy-btn:hover { opacity: 0.65; }
+
+.hex-input .clear-btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-left: var(--border-w) solid var(--ink);
+  height: 40px;
+  padding: 0 0 0 16px;
+  cursor: pointer;
+  color: var(--ink);
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s;
+}
+.hex-input .clear-btn { display: none; }
+.hex-input input[type="text"]:not(:placeholder-shown) ~ .clear-btn { display: inline-flex; }
+.hex-input .clear-btn:hover { opacity: 0.65; }
+.hex-input .clear-btn:focus-visible { outline: 2px solid var(--ink); outline-offset: -4px; }
+.hex-input .clear-btn svg { width: 18px; height: 18px; display: block; }
 .copy-btn svg { width: 16px; height: 16px; display: block; }
 .copy-btn .check-icon { display: none; }
 .copy-btn.copied .copy-icon { display: none; }
@@ -579,7 +599,6 @@ h1 {
   .row-one { min-width: 0; }
   .hex-input {
     min-width: 0;
-    padding: 0 12px;                       /* trim from 16px so 320px viewport fits */
   }
   .hex-input input[type="text"],
   .hex-input .hash {

--- a/public/style.css
+++ b/public/style.css
@@ -212,16 +212,25 @@ h1 {
   display: flex; gap: 4px; height: 44px;
   border-radius: 4px; overflow: hidden;
 }
-.alt .hex { font-size: 16px; text-align: center; color: var(--ink); font-weight: 500; white-space: nowrap; font-family: 'JetBrains Mono', monospace; }
 .alt .chip { flex: 1; }
 .alt .chip.light { background: var(--alt-light, #fff); }
 .alt .chip.dark { background: var(--alt-dark, #000); }
 .alt.single .chip { background: var(--alt-colour); }
-.alt .hex { font-size: 16px; text-align: center; color: var(--ink); font-weight: 500; white-space: nowrap; font-family: 'JetBrains Mono', monospace; }
+.alt .info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.alt .hexes, .alt .labels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  text-align: center;
+}
+.alt.single .hexes, .alt.single .labels { grid-template-columns: 1fr; }
+.alt .hexes { font-size: 16px; color: var(--ink); font-weight: 500; white-space: nowrap; }
+.alt .labels { font-size: 16px; color: #767676; font-weight: 400; }
 .alt.placeholder { cursor: default; background: transparent; border-style: dashed; opacity: 0.55; }
 .alt.placeholder .chips { background: transparent; }
 .alt.placeholder .chip { background: transparent; }
-.alt.placeholder .hex { color: var(--topbar-fg); }
+.alt.placeholder .hexes,
+.alt.placeholder .labels { color: var(--topbar-fg); }
 
 .alts-empty {
   grid-column: 1 / -1;
@@ -494,7 +503,8 @@ h1 {
   .alts-empty { padding: 10px 0; }
   .alt { flex-direction: row; align-items: center; padding: 10px 14px; gap: 14px; }
   .alt .chips { flex: 0 0 72px; height: 40px; }
-  .alt .hex { flex: 1; text-align: left; }
+  .alt .info { flex: 1; }
+  .alt .hexes, .alt .labels { text-align: left; }
 
   /* Tabs replace side-by-side previews */
   .preview-tabs { display: block; }


### PR DESCRIPTION
## Summary
- Each pair card now shows the swatches, hex codes, and a Light/Dark caption beneath so users immediately understand which shade goes on which background (a friend tester missed this signal).
- Caption colour `#767676` — 4.5:1 against the white card, AA at 16px.
- Stacked rows on desktop; chips-left + stacked info on mobile.
- Credit line: full stop after `colourcontrast.cc` swapped for an en dash, and Feedback lowercased so it reads as a continuation rather than a new sentence.

## Preview
https://alt-light-dark-labels.wcag-colour-finder.pages.dev

## Test plan
- [ ] Desktop: alt cards show 3 stacked rows (chips / hexes / labels)
- [ ] Mobile: alt cards show chips left, hexes + labels stacked right
- [ ] Light/Dark caption legible on white card
- [ ] Credit line reads "Inspired by colourcontrast.cc – feedback."

🤖 Generated with [Claude Code](https://claude.com/claude-code)