### PR TITLE
fix(cache): version-bust assets so feedback button updates on phones

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.js
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/app.js
+++ b/public/app.js
@@ -8,9 +8,9 @@
 //   - Store hex without # prefix in state; pass `'#' + hex` into contrastRatio.
 //   - Pass raw contrastRatio float to passesAA etc — never round before threshold check.
 
-import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js';
-import { findVariantPairs } from './variant-search.js';
-import { parseHashState, buildHashPath } from './url-state.js';
+import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=2';
+import { findVariantPairs } from './variant-search.js?v=2';
+import { parseHashState, buildHashPath } from './url-state.js?v=2';
 
 // --- Pure functions (exported for testing) ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
-  <script type="module" src="app.js"></script>
-  <script type="module" src="feedback.js"></script>
+  <link rel="stylesheet" href="style.css?v=2">
+  <script type="module" src="app.js?v=2"></script>
+  <script type="module" src="feedback.js?v=2"></script>
 </head>
 <body>
 <main>

--- a/public/variant-search.js
+++ b/public/variant-search.js
@@ -21,7 +21,7 @@ import {
   contrastRatio,
   passesThreshold,
   oklabDistance,
-} from './colour-engine.js';
+} from './colour-engine.js?v=2';
 
 // --- Constants ---
 


### PR DESCRIPTION
## Summary

Phones were caching the old `style.css` and `feedback.js`, so the new feedback button shipped with default browser styling (white pill) and no JS handler. Cloudflare purge clears the edge cache but not browser caches on user devices.

- Add `?v=2` to `<link>` and `<script>` tags in `public/index.html`
- Add `?v=2` to internal ES module imports in `app.js` and `variant-search.js` (those resolve as separate URLs without inheriting the parent's query string)
- Add `public/_headers` so Cloudflare Pages tells browsers to revalidate `index.html` on every load and treat versioned `*.js` / `*.css` as `immutable`

Once this deploys, phones will fetch the new HTML, see the new `?v=2` URLs, and pull fresh assets.

## Going forward

Bump `?v=N` on every deploy that changes JS or CSS. The `_headers` rules then guarantee browsers refetch.

## Test plan

- [ ] Deploy to Cloudflare Pages
- [ ] Confirm `index.html` response includes `Cache-Control: public, max-age=0, must-revalidate`
- [ ] Confirm `style.css?v=2` response includes `Cache-Control: public, max-age=31536000, immutable`
- [ ] Open on a phone that previously had the broken cached version — feedback button renders inline as an underlined link and opens the modal on tap
- [ ] Submit feedback successfully (creates a GitHub issue)

https://claude.ai/code/session_01PzuiajMdwNE6vXRB927PSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzuiajMdwNE6vXRB927PSq)_