### PR TITLE
fix(tabs): match mobile tab bg to its panel bg

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -8,9 +8,9 @@
 //   - Store hex without # prefix in state; pass `'#' + hex` into contrastRatio.
 //   - Pass raw contrastRatio float to passesAA etc — never round before threshold check.
 
-import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=2';
-import { findVariantPairs } from './variant-search.js?v=2';
-import { parseHashState, buildHashPath } from './url-state.js?v=2';
+import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=3';
+import { findVariantPairs } from './variant-search.js?v=3';
+import { parseHashState, buildHashPath } from './url-state.js?v=3';
 
 // --- Pure functions (exported for testing) ---
 
@@ -185,6 +185,11 @@ if (typeof document !== 'undefined') {
   }
 
   function renderPreviews() {
+    // Mobile tab buttons share the panel backgrounds via CSS vars so they
+    // never drift from the panel they represent.
+    document.body.style.setProperty('--light-tab-bg', '#' + state.light);
+    document.body.style.setProperty('--dark-tab-bg',  '#' + state.dark);
+
     if (state.base === null) {
       // No user hex yet — render panels with their intrinsic monochrome defaults.
       renderPanel(previewLight, '000000', state.light, lightRatioEl, lightPillsEl, lightFgHex);

--- a/public/app.js
+++ b/public/app.js
@@ -8,9 +8,9 @@
 //   - Store hex without # prefix in state; pass `'#' + hex` into contrastRatio.
 //   - Pass raw contrastRatio float to passesAA etc — never round before threshold check.
 
-import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=4';
-import { findVariantPairs } from './variant-search.js?v=4';
-import { parseHashState, buildHashPath } from './url-state.js?v=4';
+import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=5';
+import { findVariantPairs } from './variant-search.js?v=5';
+import { parseHashState, buildHashPath } from './url-state.js?v=5';
 
 // --- Pure functions (exported for testing) ---
 

--- a/public/app.js
+++ b/public/app.js
@@ -8,9 +8,9 @@
 //   - Store hex without # prefix in state; pass `'#' + hex` into contrastRatio.
 //   - Pass raw contrastRatio float to passesAA etc — never round before threshold check.
 
-import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=3';
-import { findVariantPairs } from './variant-search.js?v=3';
-import { parseHashState, buildHashPath } from './url-state.js?v=3';
+import { parseHex, contrastRatio, passesAA, passesAAA, passesAALarge, passesAAALarge } from './colour-engine.js?v=4';
+import { findVariantPairs } from './variant-search.js?v=4';
+import { parseHashState, buildHashPath } from './url-state.js?v=4';
 
 // --- Pure functions (exported for testing) ---
 
@@ -303,7 +303,11 @@ if (typeof document !== 'undefined') {
    * no array-emptiness heuristic needed.
    */
   function autoFindAndApply() {
-    if (state.base === null) return;
+    if (state.base === null) {
+      // No base hex: skip the search but still repaint, so bg changes are visible.
+      renderPreviews();
+      return;
+    }
     const targetRatio = state.target === 'AAA' ? 7.0 : 4.5;
     const raw = findVariantPairs(
       '#' + state.base,

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=4">
-  <script type="module" src="app.js?v=4"></script>
-  <script type="module" src="feedback.js?v=4"></script>
+  <link rel="stylesheet" href="style.css?v=5">
+  <script type="module" src="app.js?v=5"></script>
+  <script type="module" src="feedback.js?v=5"></script>
 </head>
 <body>
 <main>

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=2">
-  <script type="module" src="app.js?v=2"></script>
-  <script type="module" src="feedback.js?v=2"></script>
+  <link rel="stylesheet" href="style.css?v=3">
+  <script type="module" src="app.js?v=3"></script>
+  <script type="module" src="feedback.js?v=3"></script>
 </head>
 <body>
 <main>

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=3">
-  <script type="module" src="app.js?v=3"></script>
-  <script type="module" src="feedback.js?v=3"></script>
+  <link rel="stylesheet" href="style.css?v=4">
+  <script type="module" src="app.js?v=4"></script>
+  <script type="module" src="feedback.js?v=4"></script>
 </head>
 <body>
 <main>

--- a/public/style.css
+++ b/public/style.css
@@ -479,7 +479,6 @@ h1 {
   flex: 1;
   appearance: none;
   border: 0;
-  border-bottom: var(--border-w) solid var(--ink);
   background: var(--light-tab-bg, #FFFFFF);
   color: var(--light-fg, var(--ink));
   font-family: 'Inter', sans-serif;
@@ -491,9 +490,6 @@ h1 {
 .tab-btn[data-tab="dark"] {
   background: var(--dark-tab-bg, #000000);
   color: var(--dark-fg, #FFFFFF);
-}
-.tab-btn.is-active {
-  border-bottom: var(--border-w) solid transparent;
 }
 
 @media (max-width: 767px) {

--- a/public/style.css
+++ b/public/style.css
@@ -480,7 +480,7 @@ h1 {
   appearance: none;
   border: 0;
   border-bottom: var(--border-w) solid var(--ink);
-  background: #FFFFFF;
+  background: var(--light-tab-bg, #FFFFFF);
   color: var(--light-fg, var(--ink));
   font-family: 'Inter', sans-serif;
   font-weight: 700;
@@ -489,7 +489,7 @@ h1 {
   cursor: pointer;
 }
 .tab-btn[data-tab="dark"] {
-  background: var(--ink);
+  background: var(--dark-tab-bg, #000000);
   color: var(--dark-fg, #FFFFFF);
 }
 .tab-btn.is-active {

--- a/public/variant-search.js
+++ b/public/variant-search.js
@@ -21,7 +21,7 @@ import {
   contrastRatio,
   passesThreshold,
   oklabDistance,
-} from './colour-engine.js?v=4';
+} from './colour-engine.js?v=5';
 
 // --- Constants ---
 

--- a/public/variant-search.js
+++ b/public/variant-search.js
@@ -21,7 +21,7 @@ import {
   contrastRatio,
   passesThreshold,
   oklabDistance,
-} from './colour-engine.js?v=3';
+} from './colour-engine.js?v=4';
 
 // --- Constants ---
 

--- a/public/variant-search.js
+++ b/public/variant-search.js
@@ -21,7 +21,7 @@ import {
   contrastRatio,
   passesThreshold,
   oklabDistance,
-} from './colour-engine.js?v=2';
+} from './colour-engine.js?v=3';
 
 // --- Constants ---
 


### PR DESCRIPTION
## Summary

The active **Dark** mobile tab used `var(--ink)` (`#111111`) while the dark preview panel painted itself `#000000` from the `dark-bg-text` input — visibly different shades, especially on OLED phones.

- `renderPreviews` now writes `--light-tab-bg` / `--dark-tab-bg` on `<body>` from `state.light` / `state.dark`
- `.tab-btn` reads those vars, so tabs always match the panels they represent — including when the user picks custom light/dark backgrounds
- Bump assets to `?v=3` per `CLAUDE.md`

## Test plan

- [ ] On a phone, default state: Dark tab and dark preview panel are identical pure black
- [ ] Change the dark background hex to something custom (e.g. `#222222`) → Dark tab updates to match
- [ ] Same check for the light side with a custom light bg
- [ ] Reload after deploy: cached assets refresh (new `?v=3` URLs)

https://claude.ai/code/session_01PzuiajMdwNE6vXRB927PSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzuiajMdwNE6vXRB927PSq)_